### PR TITLE
URL Cleanup

### DIFF
--- a/scripts/bql.bat
+++ b/scripts/bql.bat
@@ -2,7 +2,7 @@
 REM   The contents of this file are subject to the Mozilla Public License
 REM   Version 1.1 (the "License"); you may not use this file except in
 REM   compliance with the License. You may obtain a copy of the License at
-REM   http://www.mozilla.org/MPL/
+REM   https://www.mozilla.org/MPL/
 REM
 REM   Software distributed under the License is distributed on an "AS IS"
 REM   basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/scripts/bql_dump.bat
+++ b/scripts/bql_dump.bat
@@ -2,7 +2,7 @@
 REM   The contents of this file are subject to the Mozilla Public License
 REM   Version 1.1 (the "License"); you may not use this file except in
 REM   compliance with the License. You may obtain a copy of the License at
-REM   http://www.mozilla.org/MPL/
+REM   https://www.mozilla.org/MPL/
 REM
 REM   Software distributed under the License is distributed on an "AS IS"
 REM   basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.mozilla.org/MPL/ migrated to:  
  https://www.mozilla.org/MPL/ ([https](https://www.mozilla.org/MPL/) result 301).