### PR TITLE
URL Cleanup

### DIFF
--- a/scripts/bql
+++ b/scripts/bql
@@ -2,7 +2,7 @@
 ##   The contents of this file are subject to the Mozilla Public License
 ##   Version 1.1 (the "License"); you may not use this file except in
 ##   compliance with the License. You may obtain a copy of the License at
-##   http://www.mozilla.org/MPL/
+##   https://www.mozilla.org/MPL/
 ##
 ##   Software distributed under the License is distributed on an "AS IS"
 ##   basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/scripts/bql_dump
+++ b/scripts/bql_dump
@@ -2,7 +2,7 @@
 ##   The contents of this file are subject to the Mozilla Public License
 ##   Version 1.1 (the "License"); you may not use this file except in
 ##   compliance with the License. You may obtain a copy of the License at
-##   http://www.mozilla.org/MPL/
+##   https://www.mozilla.org/MPL/
 ##
 ##   Software distributed under the License is distributed on an "AS IS"
 ##   basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/src/bql_amqp_rpc_client.erl
+++ b/src/bql_amqp_rpc_client.erl
@@ -1,7 +1,7 @@
 %%   The contents of this file are subject to the Mozilla Public License
 %%   Version 1.1 (the "License"); you may not use this file except in
 %%   compliance with the License. You may obtain a copy of the License at
-%%   http://www.mozilla.org/MPL/
+%%   https://www.mozilla.org/MPL/
 %%
 %%   Software distributed under the License is distributed on an "AS IS"
 %%   basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/src/bql_amqp_rpc_server.erl
+++ b/src/bql_amqp_rpc_server.erl
@@ -1,7 +1,7 @@
 %%   The contents of this file are subject to the Mozilla Public License
 %%   Version 1.1 (the "License"); you may not use this file except in
 %%   compliance with the License. You may obtain a copy of the License at
-%%   http://www.mozilla.org/MPL/
+%%   https://www.mozilla.org/MPL/
 %%
 %%   Software distributed under the License is distributed on an "AS IS"
 %%   basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/src/bql_applicator.erl
+++ b/src/bql_applicator.erl
@@ -1,7 +1,7 @@
 %%   The contents of this file are subject to the Mozilla Public License
 %%   Version 1.1 (the "License"); you may not use this file except in
 %%   compliance with the License. You may obtain a copy of the License at
-%%   http://www.mozilla.org/MPL/
+%%   https://www.mozilla.org/MPL/
 %%
 %%   Software distributed under the License is distributed on an "AS IS"
 %%   basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/src/bql_client.erl
+++ b/src/bql_client.erl
@@ -1,7 +1,7 @@
 %%   The contents of this file are subject to the Mozilla Public License
 %%   Version 1.1 (the "License"); you may not use this file except in
 %%   compliance with the License. You may obtain a copy of the License at
-%%   http://www.mozilla.org/MPL/
+%%   https://www.mozilla.org/MPL/
 %%
 %%   Software distributed under the License is distributed on an "AS IS"
 %%   basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/src/bql_dump.erl
+++ b/src/bql_dump.erl
@@ -1,7 +1,7 @@
 %%   The contents of this file are subject to the Mozilla Public License
 %%   Version 1.1 (the "License"); you may not use this file except in
 %%   compliance with the License. You may obtain a copy of the License at
-%%   http://www.mozilla.org/MPL/
+%%   https://www.mozilla.org/MPL/
 %%
 %%   Software distributed under the License is distributed on an "AS IS"
 %%   basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/src/bql_server.erl
+++ b/src/bql_server.erl
@@ -1,7 +1,7 @@
 %%   The contents of this file are subject to the Mozilla Public License
 %%   Version 1.1 (the "License"); you may not use this file except in
 %%   compliance with the License. You may obtain a copy of the License at
-%%   http://www.mozilla.org/MPL/
+%%   https://www.mozilla.org/MPL/
 %%
 %%   Software distributed under the License is distributed on an "AS IS"
 %%   basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/src/bql_shell.erl
+++ b/src/bql_shell.erl
@@ -1,7 +1,7 @@
 %%   The contents of this file are subject to the Mozilla Public License
 %%   Version 1.1 (the "License"); you may not use this file except in
 %%   compliance with the License. You may obtain a copy of the License at
-%%   http://www.mozilla.org/MPL/
+%%   https://www.mozilla.org/MPL/
 %%
 %%   Software distributed under the License is distributed on an "AS IS"
 %%   basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/src/bql_utils.erl
+++ b/src/bql_utils.erl
@@ -1,7 +1,7 @@
 %%   The contents of this file are subject to the Mozilla Public License
 %%   Version 1.1 (the "License"); you may not use this file except in
 %%   compliance with the License. You may obtain a copy of the License at
-%%   http://www.mozilla.org/MPL/
+%%   https://www.mozilla.org/MPL/
 %%
 %%   Software distributed under the License is distributed on an "AS IS"
 %%   basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/src/command_lexer.xrl
+++ b/src/command_lexer.xrl
@@ -1,7 +1,7 @@
 %%   The contents of this file are subject to the Mozilla Public License
 %%   Version 1.1 (the "License"); you may not use this file except in
 %%   compliance with the License. You may obtain a copy of the License at
-%%   http://www.mozilla.org/MPL/
+%%   https://www.mozilla.org/MPL/
 %%
 %%   Software distributed under the License is distributed on an "AS IS"
 %%   basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/src/command_parser.yrl
+++ b/src/command_parser.yrl
@@ -1,7 +1,7 @@
 %%   The contents of this file are subject to the Mozilla Public License
 %%   Version 1.1 (the "License"); you may not use this file except in
 %%   compliance with the License. You may obtain a copy of the License at
-%%   http://www.mozilla.org/MPL/
+%%   https://www.mozilla.org/MPL/
 %%
 %%   Software distributed under the License is distributed on an "AS IS"
 %%   basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/src/commands.erl
+++ b/src/commands.erl
@@ -1,7 +1,7 @@
 %%   The contents of this file are subject to the Mozilla Public License
 %%   Version 1.1 (the "License"); you may not use this file except in
 %%   compliance with the License. You may obtain a copy of the License at
-%%   http://www.mozilla.org/MPL/
+%%   https://www.mozilla.org/MPL/
 %%
 %%   Software distributed under the License is distributed on an "AS IS"
 %%   basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/src/rabbitmq_bql.erl
+++ b/src/rabbitmq_bql.erl
@@ -1,7 +1,7 @@
 %%   The contents of this file are subject to the Mozilla Public License
 %%   Version 1.1 (the "License"); you may not use this file except in
 %%   compliance with the License. You may obtain a copy of the License at
-%%   http://www.mozilla.org/MPL/
+%%   https://www.mozilla.org/MPL/
 %%
 %%   Software distributed under the License is distributed on an "AS IS"
 %%   basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/src/rabbitmq_bql_sup.erl
+++ b/src/rabbitmq_bql_sup.erl
@@ -1,7 +1,7 @@
 %%   The contents of this file are subject to the Mozilla Public License
 %%   Version 1.1 (the "License"); you may not use this file except in
 %%   compliance with the License. You may obtain a copy of the License at
-%%   http://www.mozilla.org/MPL/
+%%   https://www.mozilla.org/MPL/
 %%
 %%   Software distributed under the License is distributed on an "AS IS"
 %%   basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/test/amq_interface_test.erl
+++ b/test/amq_interface_test.erl
@@ -1,7 +1,7 @@
 %%   The contents of this file are subject to the Mozilla Public License
 %%   Version 1.1 (the "License"); you may not use this file except in
 %%   compliance with the License. You may obtain a copy of the License at
-%%   http://www.mozilla.org/MPL/
+%%   https://www.mozilla.org/MPL/
 %%
 %%   Software distributed under the License is distributed on an "AS IS"
 %%   basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/test/bql_client_test.erl
+++ b/test/bql_client_test.erl
@@ -1,7 +1,7 @@
 %%   The contents of this file are subject to the Mozilla Public License
 %%   Version 1.1 (the "License"); you may not use this file except in
 %%   compliance with the License. You may obtain a copy of the License at
-%%   http://www.mozilla.org/MPL/
+%%   https://www.mozilla.org/MPL/
 %%
 %%   Software distributed under the License is distributed on an "AS IS"
 %%   basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/test/command_parser_test.erl
+++ b/test/command_parser_test.erl
@@ -1,7 +1,7 @@
 %%   The contents of this file are subject to the Mozilla Public License
 %%   Version 1.1 (the "License"); you may not use this file except in
 %%   compliance with the License. You may obtain a copy of the License at
-%%   http://www.mozilla.org/MPL/
+%%   https://www.mozilla.org/MPL/
 %%
 %%   Software distributed under the License is distributed on an "AS IS"
 %%   basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.mozilla.org/MPL/ with 18 occurrences migrated to:  
  https://www.mozilla.org/MPL/ ([https](https://www.mozilla.org/MPL/) result 301).